### PR TITLE
Solving more Windows-related character problems

### DIFF
--- a/Final Project Code/terminal.cpp
+++ b/Final Project Code/terminal.cpp
@@ -14,21 +14,29 @@ void Terminal::printOptions(
 }
 
 void Terminal::trimAndRecolor(std::string& str, int width) const {
-    auto last5 = str[width - 5];
-    auto last4 = str[width - 4];
-    auto last3 = str[width - 3];
-    auto last2 = str[width - 2];
-    auto last1 = str[width - 1];
-    str.resize(width - 5);
-    str.append(colorFade1);
-    str.push_back(last5);
-    str.append(colorFade2);
-    str.push_back(last4);
-    str.append(colorFade3);
-    str.push_back(last3);
-    str.append(colorFade4);
-    str.push_back(last2);
-    str.append(colorFade5);
-    str.push_back(last1);
-    str.append(reset);
+    if constexpr(isWindows) {
+        auto last3 = str[width - 3];
+        auto last2 = str[width - 2];
+        auto last1 = str[width - 1];
+        str.resize(width - 3);
+        str.append("...");
+    } else {
+        auto last5 = str[width - 5];
+        auto last4 = str[width - 4];
+        auto last3 = str[width - 3];
+        auto last2 = str[width - 2];
+        auto last1 = str[width - 1];
+        str.resize(width - 5);
+        str.append(colorFade1);
+        str.push_back(last5);
+        str.append(colorFade2);
+        str.push_back(last4);
+        str.append(colorFade3);
+        str.push_back(last3);
+        str.append(colorFade4);
+        str.push_back(last2);
+        str.append(colorFade5);
+        str.push_back(last1);
+        str.append(reset);
+    }
 }


### PR DESCRIPTION
Your terminal is having trouble displaying some of the line characters used for the table; when you try to print them, the terminal displays a bunch of gobbledygook (?).  This change uses alternative characters for the table that your terminal should be able to display properly.

I don't know where these files are ultimately going to end up in your visual studio project.  Just pull them and move them to where they are needed.  (Probably replace your current terminal.hpp in the upper directory with the new one; leave the new terminal.cpp alone).

As always, text or call if you have problems.  I will try to respond faster than I have been.