### PR TITLE
Added ability to modify records from list of search results

### DIFF
--- a/Final Project Code/include/inventoryitem.hpp
+++ b/Final Project Code/include/inventoryitem.hpp
@@ -1,10 +1,16 @@
 #pragma once
 
+#include <filesystem>
 #include <string>
 
 class InventoryItem {
+public:
     std::string type, name, author, publisher;
     int borrowerID;
+
+    static constexpr int Offset = 0;
+    inline static const std::filesystem::path SaveFileLocation
+        = std::filesystem::current_path().append("Final Project Code/data/book.txt");
 
     enum class FieldTag {
         Type,
@@ -13,7 +19,6 @@ class InventoryItem {
         Publisher,
         BorrowerID
     };
-public:
     static constexpr auto Type = FieldTag::Type;
     static constexpr auto Name = FieldTag::Name;
     static constexpr auto Author = FieldTag::Author;
@@ -52,5 +57,13 @@ public:
         }
     }
 
+    std::string serialize() const {
+        return type + ';' +
+            name + ';' +
+            author + ';' +
+            publisher + ';' +
+            std::to_string(borrowerID);
+    }
+    
     friend class Library;
 };

--- a/Final Project Code/include/librarian.hpp
+++ b/Final Project Code/include/librarian.hpp
@@ -1,9 +1,15 @@
 #pragma once
 
+#include <filesystem>
 #include <string>
 
 class Librarian {
+public:
     std::string first, last, password;
+
+    static constexpr int Offset = 2;
+    inline static const std::filesystem::path SaveFileLocation
+        = std::filesystem::current_path().append("Final Project Code/data/librarians.txt");
 
     enum class FieldTag {
         First,
@@ -11,7 +17,6 @@ class Librarian {
         Password
     };
 
-public:
     static constexpr auto First = FieldTag::First;
     static constexpr auto Last = FieldTag::Last;
     static constexpr auto Password = FieldTag::Password;
@@ -36,5 +41,11 @@ public:
         }
     }
 
+    std::string serialize() const {
+        return first + ';' +
+            last + ';' +
+            password;
+    }
+    
     friend class Library;
 };

--- a/Final Project Code/include/library.hpp
+++ b/Final Project Code/include/library.hpp
@@ -2,15 +2,14 @@
 
 #include <cassert>
 #include <filesystem>
-#include <fstream>
-#include <ranges>
 #include <string_view>
 #include <vector>
 
 #include "inventoryitem.hpp"
-#include "user.hpp"
 #include "librarian.hpp"
-#include "zip_view.hpp"
+#include "librarystoragetype.hpp"
+#include "resultlist.hpp"
+#include "user.hpp"
 
 class Library {
     std::vector<InventoryItem> inventory{};
@@ -18,123 +17,44 @@ class Library {
     std::vector<Librarian> librarians{};
 
     /// Reads the entire contents of a file into a buffer.
-    static std::string readFile(const std::string& filename) {
-        auto path = std::filesystem::current_path().append(filename);
-        auto file = std::ifstream(path);
-        return std::string(
-            std::istreambuf_iterator<char>(file),
-            std::istreambuf_iterator<char>()
-        );
-    }
+    static std::string readFile(const std::string& filename);
 
-    // Creates a view of `std::string_view`s that are split by a delimiter.
-    static auto splitBy(const std::string_view text, const char delimiter) {
-        return std::views::split(text, delimiter)
-        | std::views::transform([](auto&& it){
-            auto [start, end] = it;
-            return std::string_view(start, end);
-        })
-        | std::views::filter([](auto&& it){ return !it.empty(); });
-    }
+    /// Creates a view of `std::string_view`s that are split by a delimiter.
+    static auto splitBy(const std::string_view text, const char delimiter);
+
+    /// Implements the searching functionality for the earch methods.
+    template <typename T> requires LibraryStorageType<T>
+    ResultList<T> searchVector(
+        std::vector<typename T::FieldTag>& fields,
+        std::vector<std::string>& values,
+        std::vector<T>& vec
+    );
 
 public:
-	Library() {
-        auto bookFileText = readFile("Final Project Code/data/book.txt");
-        for(auto line : splitBy(bookFileText, '\n')) {
-            auto segments = splitBy(line, ';');
-            auto it = segments.begin();
-            inventory.push_back(InventoryItem(
-                std::string(*it++),
-                std::string(*it++),
-                std::string(*it++),
-                std::string(*it++),
-                std::stoi(std::string(*it++))
-            ));
-        }
+	Library();
 
-        auto usersFileText = readFile("Final Project Code/data/users.txt");
-        for(auto line : splitBy(usersFileText, '\n')) {
-            auto segments = splitBy(line, ';');
-            auto it = segments.begin();
-            users.push_back(User(
-                std::stol(std::string(*it++)),
-                std::string(*it++),
-                std::string(*it++),
-                std::string(*it++),
-                std::string(*it++),
-                std::string(*it++),
-                std::string(*it++),
-                std::string(*it++),
-                std::stol(std::string(*it++)),
-                std::stoi(std::string(*it++))
-            ));
-        }
-
-        auto librariansFileText = readFile("Final Project Code/data/librarians.txt");
-        for(auto line : splitBy(librariansFileText, '\n')) {
-            auto segments = splitBy(line, ';');
-            auto it = segments.begin();
-            librarians.push_back(Librarian(
-                std::string(*it++),
-                std::string(*it++),
-                std::string(*it++)
-            ));
-        }
-    }
-
-    auto search(
+    /// Searches the library for inventory items based on the given fields.
+    ResultList<InventoryItem> search(
         std::vector<InventoryItem::FieldTag> fields,
         std::vector<std::string> values
-    ) const {
-        assert(fields.size() == values.size());
+    );
 
-        std::vector<InventoryItem> results;
-        for(auto& item : inventory) {
-            for(const auto& [field, value] : c9::zip(fields, values)) {
-                if(!item.matches(field, value)) {
-                    break;
-                }
-                results.push_back(item);
-            }
-        }
-        return results;
-        end:;
-    }
-
-    auto search(
+    /// Searches the library for users based on the given fields.
+    ResultList<User> search(
         std::vector<User::FieldTag> fields,
         std::vector<std::string> values
-    ) const {
-        assert(fields.size() == values.size());
+    );
 
-        std::vector<User> results;
-        for(auto& user : users) {
-            for(const auto& [field, value] : c9::zip(fields, values)) {
-                if(!user.matches(field, value)) goto end;
-            }
-            results.push_back(user);
-        end:;
-        }
-        return results;
-    }
-
-    auto search(
+    /// Searches the library for librarians based on the given fields.
+    ResultList<Librarian> search(
         std::vector<Librarian::FieldTag> fields,
         std::vector<std::string> values
-    ) const {
-        assert(fields.size() == values.size());
+    );
 
-        std::vector<Librarian> results;
-        for(auto& librarian : librarians) {
-            for(const auto& [field, value] : c9::zip(fields, values)) {
-                if(!librarian.matches(field, value)) {
-                    goto end;
-                }
-            }
-            results.push_back(librarian);
-        end:;
-        }
+    /// Writes the entire contents of a buffer to a file.
+    template <typename T> requires LibraryStorageType<T>
+    void flushVector();
 
-        return results;
-    }
+    /// Writes all the contents to disk.
+    void flush();
 }; 

--- a/Final Project Code/include/librarystoragetype.hpp
+++ b/Final Project Code/include/librarystoragetype.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <concepts>
+#include <filesystem>
+#include <type_traits>
+
+#include "inventoryitem.hpp"
+#include "librarian.hpp"
+#include "user.hpp"
+
+template <typename T>
+concept LibraryStorageType = (
+    std::is_same_v<T, User> ||
+    std::is_same_v<T, InventoryItem> ||
+    std::is_same_v<T, Librarian>) &&
+    requires (T t) {
+        typename T::FieldTag;
+        { T::Offset } -> std::convertible_to<int>;
+        { T::SaveFileLocation } -> std::same_as<const std::filesystem::path&>;
+    };

--- a/Final Project Code/include/resultlist.hpp
+++ b/Final Project Code/include/resultlist.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <vector>
+
+#include "librarystoragetype.hpp"
+
+class Library;
+
+template <typename T> requires LibraryStorageType<T>
+class ResultList {
+    std::vector<T*> items;
+    Library& lib;
+    bool modified = false;
+
+    ResultList(Library& lib, std::vector<T*>&& items) : items(items), lib(lib) {}
+    
+public:
+    ResultList(ResultList& lib) = delete;
+    ResultList(const ResultList& other) = delete;
+
+    ResultList& operator=(const ResultList& other) = delete;
+    ResultList& operator=(ResultList&& other) = delete;
+    
+    ~ResultList();
+    
+    T& operator[](int index);
+    const T& operator[](int index) const;
+
+    int size() const;
+
+    friend class Library;
+};

--- a/Final Project Code/include/user.hpp
+++ b/Final Project Code/include/user.hpp
@@ -1,11 +1,17 @@
 #pragma once
 
+#include <filesystem>
 #include <string>
 
 class User {
+public:
     std::string role, first, last, address, phone, email, password;
     long id, institutionId;
     int numCheckedOut;
+
+    static constexpr int Offset = 1;
+    inline static const std::filesystem::path SaveFileLocation
+        = std::filesystem::current_path().append("Final Project Code/data/users.txt");
 
     enum class FieldTag {
         Role,
@@ -19,7 +25,6 @@ class User {
         NumCheckedOut
     };
 
-public:
     static constexpr auto Role = FieldTag::Role;
     static constexpr auto First = FieldTag::First;
     static constexpr auto Last = FieldTag::Last;
@@ -75,6 +80,19 @@ public:
                 return numCheckedOut == stoi(value);
         }
         throw "Unreachable";
+    }
+
+    std::string serialize() const {
+        return std::to_string(id) + ';' +
+            role + ';' +
+            first + ';' +
+            last + ';' +
+            address + ';' +
+            phone + ';' +
+            email + ';' +
+            password + ';' +
+            std::to_string(institutionId) + ';' +
+            std::to_string(numCheckedOut);
     }
 
     friend class Library;

--- a/Final Project Code/src/library.cpp
+++ b/Final Project Code/src/library.cpp
@@ -1,0 +1,132 @@
+#include "library.hpp"
+#include "zip_view.hpp"
+#include <fstream>
+
+/// Reads the entire contents of a file into a buffer.
+std::string Library::readFile(const std::string& filename) {
+    auto path = std::filesystem::current_path().append(filename);
+    std::ifstream file = std::ifstream(path);
+    return std::string(
+        std::istreambuf_iterator<char>(file),
+        std::istreambuf_iterator<char>()
+    );
+}
+
+// Creates a view of `std::string_view`s that are split by a delimiter.
+auto Library::splitBy(const std::string_view text, const char delimiter) {
+    return std::views::split(text, delimiter)
+    | std::views::transform([](auto&& it){
+        auto [start, end] = it;
+        return std::string_view(start, end);
+    })
+    | std::views::filter([](auto&& it){ return !it.empty(); });
+}
+
+template <typename T> requires LibraryStorageType<T>
+void Library::flushVector() {
+    auto vec = (std::vector<T>*)(this) + T::Offset;
+    auto file = std::ofstream(T::SaveFileLocation);
+    for(auto& item : *vec) {
+        file << item.serialize() << '\n';
+    }
+    file.close();
+}
+
+template <typename T> requires LibraryStorageType<T>
+ResultList<T> Library::searchVector(
+    std::vector<typename T::FieldTag>& fields,
+    std::vector<std::string>& values,
+    std::vector<T>& vec
+) {
+    assert(fields.size() == values.size());
+
+    std::vector<T*> results;
+    for(auto& item: vec) {
+        for(const auto& [field, value] : c9::zip(fields, values)) {
+            if(!item.matches(field, value)) {
+                goto end;
+            }
+        }
+        results.push_back(&item);
+    end:;
+    }
+
+    return ResultList(*this, std::move(results));
+}
+
+Library::Library() {
+    auto bookFileText = readFile("Final Project Code/data/book.txt");
+    for(auto line : splitBy(bookFileText, '\n')) {
+        auto segments = splitBy(line, ';');
+        auto it = segments.begin();
+        inventory.push_back(InventoryItem(
+            std::string(*it++),
+            std::string(*it++),
+            std::string(*it++),
+            std::string(*it++),
+            std::stoi(std::string(*it++))
+        ));
+    }
+
+    auto usersFileText = readFile("Final Project Code/data/users.txt");
+    for(auto line : splitBy(usersFileText, '\n')) {
+        auto segments = splitBy(line, ';');
+        auto it = segments.begin();
+        users.push_back(User(
+            std::stol(std::string(*it++)),
+            std::string(*it++),
+            std::string(*it++),
+            std::string(*it++),
+            std::string(*it++),
+            std::string(*it++),
+            std::string(*it++),
+            std::string(*it++),
+            std::stol(std::string(*it++)),
+            std::stoi(std::string(*it++))
+        ));
+    }
+
+    auto librariansFileText = readFile("Final Project Code/data/librarians.txt");
+    for(auto line : splitBy(librariansFileText, '\n')) {
+        auto segments = splitBy(line, ';');
+        auto it = segments.begin();
+        librarians.push_back(Librarian(
+            std::string(*it++),
+            std::string(*it++),
+            std::string(*it++)
+        ));
+    }
+}
+
+
+
+/// Searches the library for inventory items based on the given fields.
+ResultList<InventoryItem> Library::search(
+    std::vector<InventoryItem::FieldTag> fields,
+    std::vector<std::string> values
+) {
+    return searchVector(fields, values, inventory);
+}
+
+/// Searches the library for users based on the given fields.
+ResultList<User> Library::search(
+    std::vector<User::FieldTag> fields,
+    std::vector<std::string> values
+) {
+    return searchVector(fields, values, users);
+}
+
+/// Searches the library for librarians based on the given fields.
+ResultList<Librarian> Library::search(
+    std::vector<Librarian::FieldTag> fields,
+    std::vector<std::string> values
+) {
+    return searchVector(fields, values, librarians);
+}
+
+// Writes all the contents to disk.
+void Library::flush() {
+    Library::flushVector<InventoryItem>();
+    Library::flushVector<User>();
+    Library::flushVector<Librarian>();
+}

--- a/Final Project Code/src/main.cpp
+++ b/Final Project Code/src/main.cpp
@@ -1,159 +1,179 @@
- // Final Project Code.cpp : This file contains the 'main' function. Program execution begins and ends there.
-//
-
 #include <cstdio>
-#include <filesystem>
 #include <iostream>
 #include <fstream>
 #include <sstream>
 #include <string>
-#include <iomanip>
-#include <filesystem>
+#include <vector>
 #include "terminal.hpp"
 #include "RegisterUser.hpp"
 #include "SearchFunction.hpp"
 #include "Borrowing.hpp"
 #include "UserLogin.hpp"
 #include "Admin.hpp"
+#include "inventoryitem.hpp"
+#include "library.hpp"
+#include "user.hpp"
 
 using namespace std;
 
 int main()
 {
-    Terminal term = Terminal();
-    int choice;
-    while (true) {
-        cout << "\nLibrary Management System\n";
-        cout << "1. Register New User\n2. Admin Login\n3. User Login\n4. Exit\n";
-        cout << "Enter your choice: ";
-        cin >> choice;
+    Terminal term;
+    Library lib;
 
-        switch (choice) {
-        case 1: {// register new users
-            static int nextID = 1; // Replace with a function that finds next ID if needed
-            RegisterUser newUser;
-            newUser.promptUserData(nextID++);
-            newUser.printSummary();
-            newUser.saveToFile("Final Project Code/data/users.txt");
-            break;
-        }//end of case 1
-        case 2: { // Admin login (librarian) 
+    {
+        std::vector<string> queries;
 
-            string inputFirst, inputLast, inputPass;
-            cout << "Enter admin first name: ";
-            getline(cin >> ws, inputFirst);
+        cout << "Enter a first name:" << endl;
+        string firstName = term.promptForInput<string>();
+        queries.push_back(firstName);
 
-            cout << "Enter admin last name: ";
-            getline(cin >> ws, inputLast);
+        cout << "Enter a last name:" << endl;
+        string lastName = term.promptForInput<string>();
+        queries.push_back(lastName);
 
-            cout << "Enter admin password: ";
-            getline(cin >> ws, inputPass);
+        auto results = lib.search(
+            {User::First, User::Last},
+            queries
+        );
 
-            ifstream adminFile("Final Project Code/data/librarians.txt"); 
-            if (!adminFile) {
-                cerr << "Failed to open librarian file. Check the path.\n";
-                break;
-            }
+        cout << results[0].email << endl;
 
-            string line;
-            bool authenticated = false;
+        cout << "Enter a new email:" << endl;
+        string newEmail = term.promptForInput<string>();
 
-            while (getline(adminFile, line)) {
-                stringstream ss(line);
-                string first, last, storedPass;
-
-                getline(ss, first, ';');
-                getline(ss, last, ';');
-                getline(ss, storedPass);
-
-                if (inputFirst == first && inputLast == last && inputPass == storedPass) {
-                    authenticated = true;
-                    break;
-                }
-            }
-
-            if (authenticated) {
-                cout << "Admin login successful.\n";
-                string fullName = inputFirst + " " + inputLast;
-                Admin admin(fullName, inputPass);
-                admin.showMenu();
-            }
-            else {
-                cout << "Invalid admin credentials.\n";
-            }
-
-            break;
-        }//end of case 2
-
-        case 3: { // User Login using User ID
-            string inputID, inputPassword;
-            cout << "Enter your User ID (10 digits): ";
-            cin >> inputID;
-            cout << "Enter your password: ";
-            cin >> inputPassword;
-
-            ifstream userFile("Final Project Code/data/users.txt");
-            if (!userFile) {
-                cerr << "Error: Could not open users.txt.\n";
-                break;
-            }
-
-            string line;
-            bool authenticated = false;
-
-            while (getline(userFile, line)) {
-                stringstream ss(line);
-                string libraryID, userType, firstName, lastName, address, phone, email, password, schoolID, isActive;
-
-                getline(ss, libraryID, ';');
-                getline(ss, userType, ';');
-                getline(ss, firstName, ';');
-                getline(ss, lastName, ';');
-                getline(ss, address, ';');
-                getline(ss, phone, ';');
-                getline(ss, email, ';');
-                getline(ss, password, ';');
-                getline(ss, schoolID, ';');
-                getline(ss, isActive);
-
-                if (inputID == libraryID && inputPassword == password && isActive == "1") {
-                    authenticated = true;
-                    break;
-                }
-            }
-
-            userFile.close();
-
-            if (authenticated) {
-                cout << "User login successful.\n";
-                UserLogin u(inputID, inputPassword);
-                u.showMenu();
-            }
-            else {
-                cout << "Invalid User ID or password.\n";
-            }
-
-            break;
-        }// end of case 3
-
-        case 4: //Exit Program
-            cout << "Exiting system.\n";
-            return 0;
-        default:
-            cout << "Invalid choice. Try again.\n";
-        }
+        results[0].email = newEmail;
     }
-    return 0;
 
-} // end of main
+    const auto results = lib.search(
+        {User::First, User::Last},
+        {"John", "Mandler"}
+    );
+    cout << endl << results[0].email << endl;
 
-// Run program: Ctrl + F5 or Debug > Start Without Debugging menu
-// Debug program: F5 or Debug > Start Debugging menu
 
-// Tips for Getting Started: 
-//   1. Use the Solution Explorer window to add/manage files
-//   2. Use the Team Explorer window to connect to source control
-//   3. Use the Output window to see build output and other messages
-//   4. Use the Error List window to view errors
-//   5. Go to Project > Add New Item to create new code files, or Project > Add Existing Item to add existing code files to the project
-//   6. In the future, to open this project again, go to File > Open > Project and select the .sln file
+
+
+
+    //while (true) {
+    //    cout << "\nLibrary Management System\n";
+    //    term.printOptions("Library Management System", {
+    //        "Register New User",
+    //        "Admin Login",
+    //        "User Login",
+    //        "Exit"
+    //    });
+    //    auto choice = term.promptForInput<int>();
+
+    //    switch (choice) {
+    //        case 1: {// register new users
+    //            static int nextID = 1; // Replace with a function that finds next ID if needed
+    //            RegisterUser newUser;
+    //            newUser.promptUserData(nextID++);
+    //            newUser.printSummary();
+    //            newUser.saveToFile("Final Project Code/data/users.txt");
+    //            break;
+    //        }//end of case 1
+    //        case 2: { // Admin login (librarian) 
+    //            string inputFirst, inputLast, inputPass;
+
+    //            //do {
+    //            //    cout << "Enter admin first name: " << endl;
+    //            //    inputFirst = term.promptForInput<string>();
+
+    //            //    cout << "Enter admin last name: " << endl;
+    //            //    inputLast = term.promptForInput<string>();
+
+    //            //} while ();
+    //            cout << "Enter admin password: " << endl;
+    //            inputPass = term.promptForInput<string>();
+
+    //            string line;
+    //            bool authenticated = false;
+    //            std::ifstream adminFile("Final Project Code/data/librarians.txt");
+    //            while (getline(adminFile, line)) {
+    //                stringstream ss(line);
+    //                string first, last, storedPass;
+
+    //                getline(ss, first, ';');
+    //                getline(ss, last, ';');
+    //                getline(ss, storedPass);
+
+    //                if (inputFirst == first && inputLast == last && inputPass == storedPass) {
+    //                    authenticated = true;
+    //                    break;
+    //                }
+    //            }
+
+    //            if (authenticated) {
+    //                cout << "Admin login successful.\n";
+    //                string fullName = inputFirst + " " + inputLast;
+    //                Admin admin(fullName, inputPass);
+    //                admin.showMenu();
+    //            }
+    //            else {
+    //                cout << "Invalid admin credentials.\n";
+    //            }
+
+    //            break;
+    //        }//end of case 2
+
+    //        case 3: { // User Login using User ID
+    //            string inputID, inputPassword;
+    //            cout << "Enter your User ID (10 digits): ";
+    //            cin >> inputID;
+    //            cout << "Enter your password: ";
+    //            cin >> inputPassword;
+
+    //            ifstream userFile("Final Project Code/data/users.txt");
+    //            if (!userFile) {
+    //                cerr << "Error: Could not open users.txt.\n";
+    //                break;
+    //            }
+
+    //            string line;
+    //            bool authenticated = false;
+
+    //            while (getline(userFile, line)) {
+    //                stringstream ss(line);
+    //                string libraryID, userType, firstName, lastName, address, phone, email, password, schoolID, isActive;
+
+    //                getline(ss, libraryID, ';');
+    //                getline(ss, userType, ';');
+    //                getline(ss, firstName, ';');
+    //                getline(ss, lastName, ';');
+    //                getline(ss, address, ';');
+    //                getline(ss, phone, ';');
+    //                getline(ss, email, ';');
+    //                getline(ss, password, ';');
+    //                getline(ss, schoolID, ';');
+    //                getline(ss, isActive);
+
+    //                if (inputID == libraryID && inputPassword == password && isActive == "1") {
+    //                    authenticated = true;
+    //                    break;
+    //                }
+    //            }
+
+    //            userFile.close();
+
+    //            if (authenticated) {
+    //                cout << "User login successful.\n";
+    //                UserLogin u(inputID, inputPassword);
+    //                u.showMenu();
+    //            }
+    //            else {
+    //                cout << "Invalid User ID or password.\n";
+    //            }
+
+    //            break;
+    //        }// end of case 3
+
+    //        case 4: //Exit Program
+    //            cout << "Exiting system.\n";
+    //            return 0;
+    //        default:
+    //            cout << "Invalid choice. Try again.\n";
+    //    }
+    //}
+}

--- a/Final Project Code/src/resultlist.cpp
+++ b/Final Project Code/src/resultlist.cpp
@@ -1,0 +1,35 @@
+#include "resultlist.hpp"
+#include "library.hpp"
+
+#include <cassert>
+
+template <typename T> requires LibraryStorageType<T>
+ResultList<T>::~ResultList() {
+    if (modified) {
+        lib.flushVector<T>();
+    }
+}
+
+template <typename T> requires LibraryStorageType<T>
+T& ResultList<T>::operator[](int index) {
+    assert(index >= 0 && index < items.size());
+
+    modified = true;
+    return *items[index];
+}
+
+template <typename T> requires LibraryStorageType<T>
+const T& ResultList<T>::operator[](int index) const {
+    assert(index >= 0 && index < items.size());
+
+    return *items[index];
+}
+
+template <typename T> requires LibraryStorageType<T>
+int ResultList<T>::size() const {
+    return items.size();
+}
+
+template class ResultList<InventoryItem>;
+template class ResultList<User>;
+template class ResultList<Librarian>;


### PR DESCRIPTION
Now, after you get a list of search results, you can modify the objects directly, not just read them:
```c++
int main() {
    Library lib;
    Terminal term;

    // Get user's first and last name:
    cout << "Enter a first name:" << endl;
    auto first = term.promptForInput<string>();
    cout << "Enter a last name:" << endl;
    auto last = term.promptForInput<string>();

    // Search for all applicable users:
    auto searchResults = lib.search(
        { User::First, User::Second },
        { first, second }
    );

    // Print the emails of these users:
    cout << "Emails:" << endl;
    for(int i = 0; i < searchResults.size(); i++) {
        cout << searchResults[i].email << endl;
    }
    
    // Set the phone number of the first person in the search result list:
    searchResults[0].phone = "(123) 456-7890";

    // Changes magically get written to 'users.txt'!
}
```