### PR TITLE
Fixed abort errors

### DIFF
--- a/Final Project Code/include/history.hpp
+++ b/Final Project Code/include/history.hpp
@@ -12,7 +12,9 @@ public:
 
     static constexpr int Offset = 2;
     inline static const auto SaveFileLocation
-        = std::filesystem::path(Printable<3>::SaveFileLocation) / "history.txt";
+        = std::filesystem::current_path().filename() == "Final-Project-Code"
+        ? std::filesystem::current_path() / "Final Project Code" / "data" / "history.txt"
+        : std::filesystem::current_path() / "data" / "history.txt";
 
     enum class FieldTag {
         UserID,

--- a/Final Project Code/include/inventoryitem.hpp
+++ b/Final Project Code/include/inventoryitem.hpp
@@ -16,7 +16,9 @@ public:
 
     static constexpr int Offset = 0;
     inline static const auto SaveFileLocation
-        = std::filesystem::path(Printable<5>::SaveFileLocation) / "book.txt";
+        = std::filesystem::current_path().filename() == "Final-Project-Code"
+        ? std::filesystem::current_path() / "Final Project Code" / "data" / "book.txt"
+        : std::filesystem::current_path() / "data" / "book.txt";
 
     enum class FieldTag {
         Type,

--- a/Final Project Code/include/librarian.hpp
+++ b/Final Project Code/include/librarian.hpp
@@ -9,9 +9,11 @@ class Librarian : public Printable<3> {
 public:
     std::string first, last, password;
 
-    static constexpr int Offset = 2;
+    static constexpr int Offset = 3;
     inline static const auto SaveFileLocation
-        = std::filesystem::path(Printable<3>::SaveFileLocation) / "librarians.txt";
+        = std::filesystem::current_path().filename() == "Final-Project-Code"
+        ? std::filesystem::current_path() / "Final Project Code" / "data" / "librarians.txt"
+        : std::filesystem::current_path() / "data" / "librarians.txt";
 
     enum class FieldTag {
         First,

--- a/Final Project Code/include/printable.hpp
+++ b/Final Project Code/include/printable.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <array>
-#include <filesystem>
 #include <string>
 
 /// An interface for types that can provide information to a table.
@@ -9,16 +8,6 @@
 template <int N>
 class Printable {
 public:
-    #ifdef _WIN32
-    // Visual Studio path.
-    inline static const auto SaveFileLocation
-        = std::filesystem::current_path() / "data";
-    #else
-    // Ninja path.
-    inline static const auto SaveFileLocation
-        = std::filesystem::current_path() / "Final Project Code/data";
-    #endif
-
     virtual ~Printable() {}
     virtual std::array<std::string, N> providePrintableData() const = 0;
 };

--- a/Final Project Code/include/user.hpp
+++ b/Final Project Code/include/user.hpp
@@ -13,7 +13,9 @@ public:
 
     static constexpr int Offset = 1;
     inline static const auto SaveFileLocation
-        = std::filesystem::path(Printable<10>::SaveFileLocation) / "users.txt";
+        = std::filesystem::current_path().filename() == "Final-Project-Code"
+        ? std::filesystem::current_path() / "Final Project Code" / "data" / "users.txt"
+        : std::filesystem::current_path() / "data" / "users.txt";
 
     enum class FieldTag {
         ID,

--- a/Final Project Code/src/history.cpp
+++ b/Final Project Code/src/history.cpp
@@ -1,4 +1,5 @@
 #include "history.hpp"
+#include <string>
 
 HistoryItem::HistoryItem(long userID, std::string&& name)
 : userID(userID),
@@ -8,7 +9,7 @@ HistoryItem::HistoryItem(long userID, std::string&& name)
 bool HistoryItem::matches(HistoryItem::FieldTag field, const std::string& value) const {
     switch (field) {
         case UserID:
-            return userID == stol(value);
+            return userID == std::stoll(value);
         case Name:
             return name == value;
     }

--- a/Final Project Code/src/library.cpp
+++ b/Final Project Code/src/library.cpp
@@ -1,6 +1,9 @@
 #include "library.hpp"
-#include "zip_view.hpp"
+#include <algorithm>
 #include <fstream>
+#include <string>
+#include <string_view>
+#include <vector>
 
 using namespace std;
 
@@ -16,12 +19,20 @@ std::string Library::readFile(const std::string& filename) {
 
 // Creates a view of `std::string_view`s that are split by a delimiter.
 auto Library::splitBy(const std::string_view text, const char delimiter) {
-    return std::views::split(text, delimiter)
-    | std::views::transform([](auto&& it){
-        auto [start, end] = it;
-        return std::string_view(start, end);
-    })
-    | std::views::filter([](auto&& it){ return !it.empty(); });
+    std::vector<std::string_view> res;
+    int pos = 0;
+    auto end = text.find(delimiter, pos);
+    while (pos < text.size() && end != std::string_view::npos) {
+        if (end - pos > 0) {
+            res.push_back(text.substr(pos, end - pos));
+        }
+        pos = end + 1;
+        end = text.find(delimiter, pos);
+    }
+    if (text.substr(pos).size() > 0) {
+        res.push_back(text.substr(pos));
+    }
+    return res;
 }
 
 template <typename T> requires LibraryStorageType<T>
@@ -57,55 +68,51 @@ ResultList<T> Library::searchVector(
 }
 
 Library::Library() {
-    auto bookFileText = readFile("Final Project Code/data/book.txt");
-    for(auto line : splitBy(bookFileText, '\n')) {
+    auto bookFileText = readFile(InventoryItem::SaveFileLocation);
+    for(auto& line : splitBy(bookFileText, '\n')) {
         auto segments = splitBy(line, ';');
-        auto it = segments.begin();
         inventory.push_back(InventoryItem(
-            std::string(*it++),
-            std::string(*it++),
-            std::string(*it++),
-            std::string(*it++),
-            std::stoi(std::string(*it++))
+            std::string(segments[0]),
+            std::string(segments[1]),
+            std::string(segments[2]),
+            std::string(segments[3]),
+            std::stoi(std::string(segments[4]))
         ));
     }
 
-    auto usersFileText = readFile("Final Project Code/data/users.txt");
-    for(auto line : splitBy(usersFileText, '\n')) {
+    auto usersFileText = readFile(User::SaveFileLocation);
+    for(auto& line : splitBy(usersFileText, '\n')) {
         auto segments = splitBy(line, ';');
-        auto it = segments.begin();
         users.push_back(User(
-            std::stol(std::string(*it++)),
-            std::string(*it++),
-            std::string(*it++),
-            std::string(*it++),
-            std::string(*it++),
-            std::string(*it++),
-            std::string(*it++),
-            std::string(*it++),
-            std::stol(std::string(*it++)),
-            std::stoi(std::string(*it++))
+            std::stoll(std::string(segments[0])),
+            std::string(segments[1]),
+            std::string(segments[2]),
+            std::string(segments[3]),
+            std::string(segments[4]),
+            std::string(segments[5]),
+            std::string(segments[6]),
+            std::string(segments[7]),
+            std::stoll(std::string(segments[8])),
+            std::stoi(std::string(segments[9]))
         ));
     }
 
-    auto historyFileText = readFile("Final Project Code/data/history.txt");
-    for(auto line : splitBy(historyFileText, '\n')) {
+    auto historyFileText = readFile(HistoryItem::SaveFileLocation);
+    for(auto& line : splitBy(historyFileText, '\n')) {
         auto segments = splitBy(line, ';');
-        auto it = segments.begin();
         history.push_back(HistoryItem(
-            std::stol(std::string(*it++)),
-            std::string(*it++)
+            std::stoll(std::string(segments[0])),
+            std::string(segments[1])
         ));
     }
 
-    auto librariansFileText = readFile("Final Project Code/data/librarians.txt");
-    for(auto line : splitBy(librariansFileText, '\n')) {
+    auto librariansFileText = readFile(Librarian::SaveFileLocation);
+    for(auto& line : splitBy(librariansFileText, '\n')) {
         auto segments = splitBy(line, ';');
-        auto it = segments.begin();
         librarians.push_back(Librarian(
-            std::string(*it++),
-            std::string(*it++),
-            std::string(*it++)
+            std::string(segments[0]),
+            std::string(segments[1]),
+            std::string(segments[2])
         ));
     }
 }

--- a/Final Project Code/src/user.cpp
+++ b/Final Project Code/src/user.cpp
@@ -1,5 +1,6 @@
 #include "user.hpp"
 #include "util.hpp"
+#include <string>
 
 User::User(
     long id,
@@ -27,7 +28,7 @@ User::User(
 bool User::matches(User::FieldTag field, const std::string& value) const noexcept {
     switch (field) {
         case ID:
-            return id == stol(value);
+            return id == std::stoll(value);
         case Role:
             return role == value;
         case First:
@@ -43,9 +44,9 @@ bool User::matches(User::FieldTag field, const std::string& value) const noexcep
         case Password:
             return password == value;
         case InstitutionID:
-            return institutionId == stol(value);
+            return institutionId == std::stoll(value);
         case NumCheckedOut:
-            return numCheckedOut == stoi(value);
+            return numCheckedOut == std::stoi(value);
     }
     UNREACHABLE;
 }


### PR DESCRIPTION
The errors were mostly because of platform-specific implementations of certain standard library functions.  These changes let us work around the issues.